### PR TITLE
aodn/aodn-portal#1473 - fix issue with requests becoming slower and slow...

### DIFF
--- a/jeeves/src/main/java/jeeves/config/springutil/JeevesApplicationContext.java
+++ b/jeeves/src/main/java/jeeves/config/springutil/JeevesApplicationContext.java
@@ -22,17 +22,16 @@ public class JeevesApplicationContext extends XmlWebApplicationContext {
     
     public JeevesApplicationContext(final ConfigurationOverrides configurationOverrides) {
         this._configurationOverrides = configurationOverrides;
-        addApplicationListener(new ApplicationListener<ApplicationEvent>() {
+    }
 
-            @Override
-            public void onApplicationEvent(ApplicationEvent event) {
-                try {
-                    configurationOverrides.applyNonImportSpringOverides(JeevesApplicationContext.this, getServletContext(), appPath);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
+    @Override
+    protected void finishRefresh() {
+        try {
+            _configurationOverrides.applyNonImportSpringOverides(JeevesApplicationContext.this, getServletContext(), appPath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        super.finishRefresh();
     }
 
     public void setAppPath(String appPath) {


### PR DESCRIPTION
...er over time

Was adding security matching rules defined in configuration overrides to list of rules to check every time an ApplicationEvent occurred, instead of just once when the application context is loaded.

Apply core Geonetwork fix made in develop branch.
