### PR TITLE
Handle absolute download links

### DIFF
--- a/web/src/main/webapp/scripts/editor/metadata-show.js
+++ b/web/src/main/webapp/scripts/editor/metadata-show.js
@@ -170,6 +170,8 @@
 			function runFileDownload(href,title) {
 				if (href.include("resources.get")) { // do the file download direct
 					location.replace(getGNServiceURL(href));
+                } else if (href.toLowerCase().include("http")) { // do the file download direct
+                    location.replace(href)
 				} else { // show some dialog beforehand eg. constraints
 					Modalbox.show(getGNServiceURL(href),{title:title, height:400, width:600});
 				}


### PR DESCRIPTION
These seem to appear in the metadata view page, but not in the search results.  To be honest, I'm not sure if this is the right place, or if it's an XSL fix.

See #34 