### PR TITLE
Expose additional citation fields in summary

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -136,6 +136,13 @@
       <field name="tempExtentEnd" tagName="tempExtentEnd"/>
       <field name="geoPolygon" tagName="geoPolygon"/>
 
+      <!-- citation feature: -->
+      <field name="jurisdictionLink" tagName="jurisdictionLink" />
+      <field name="licenseLink" tagName="licenseLink" />
+      <field name="licenseName" tagName="licenseName" />
+      <field name="attrConstr" tagName="attrConstr" />
+      <field name="otherCitation" tagName="otherCitation" />
+      <field name="useLimitation" tagName="useLimitation" />
     </dumpFields>
   </search>
 


### PR DESCRIPTION
The portal citation-feature needs additional citation-related attributes
available, such as usage limitations and licensing information.  Some of
these are already exposed, but all under the generic Constraints
tagname.  We repeat these here so as not to break current consumers of
that tag, using distinct tag names each.

This will also require an update to the schema plugins (aodn/schema-plugins#17)