### PR TITLE
2.10.x imos link monitor alg change

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/search/CollectionAvailabilityFilter.java
+++ b/web/src/main/java/org/fao/geonet/kernel/search/CollectionAvailabilityFilter.java
@@ -55,7 +55,8 @@ public class CollectionAvailabilityFilter extends Filter {
                     document = reader.document(docBase + doc, _fieldsToLoad);
                     String uuid = document.get("_uuid");
 
-                    if (_geonetContext != null && ! _geonetContext.getLinkMonitor().isHealthy(uuid)) {
+                    if (_geonetContext != null && _geonetContext.getLinkMonitor() != null &&
+                        ! _geonetContext.getLinkMonitor().isHealthy(uuid)) {
                         Log.debug(this.getClass().getSimpleName(), String.format("'%s' is unavailable - omitting from search results", uuid));
                     } else {
                         bits.set(docBase + doc);

--- a/web/src/main/java/org/fao/geonet/monitor/link/LinkMonitorService.java
+++ b/web/src/main/java/org/fao/geonet/monitor/link/LinkMonitorService.java
@@ -80,6 +80,9 @@ public class LinkMonitorService implements LinkMonitorInterface {
         this.freshness = Integer.parseInt(serviceConfig.getValue(LINK_MONITOR_SERVICE_FRESHNESS, "3600"));
         this.unknownAsWorking = Boolean.parseBoolean(serviceConfig.getValue(LINK_MONITOR_SERVICE_UNKNOWNASWORKING, "true"));
         this.betweenChecksIntervalMs = Integer.parseInt(serviceConfig.getValue(LINK_MONITOR_SERVICE_BETWEENCHECKSINTERVALMS, "100"));
+
+        if (percentWorkingThreshold > 100) percentWorkingThreshold = 100;
+        if (percentWorkingThreshold < 0) percentWorkingThreshold = 0;
     }
 
     @Override

--- a/web/src/test/java/org/fao/geonet/monitor/link/LinkInfoTest.java
+++ b/web/src/test/java/org/fao/geonet/monitor/link/LinkInfoTest.java
@@ -21,6 +21,11 @@ public class LinkInfoTest extends TestCase {
         public String toString() {
             return "";
         }
+
+        @Override
+        public boolean canHandle(String linkType) {
+            return true;
+        }
     }
 
     public void testGetStatus() throws Exception {
@@ -33,9 +38,9 @@ public class LinkInfoTest extends TestCase {
         // No checks done - status should be UNKNOWN
         assertEquals(LinkMonitorService.Status.UNKNOWN, linkInfo.getStatus());
 
-        // One check out of 3 done - status should still be UNKNOWN
+        // One check out of 3 done - status should be WORKING
         linkInfo.check();
-        assertEquals(LinkMonitorService.Status.UNKNOWN, linkInfo.getStatus());
+        assertEquals(LinkMonitorService.Status.WORKING, linkInfo.getStatus());
 
         // 3 checks done, should be WORKING
         linkInfo.check();


### PR DESCRIPTION
As per @pblain 's request. Algorithm for determining `UNKNOWN`, `FAILED`, `WORKING` has slightly changed. Best if you look at the modified source without the diff:
https://github.com/aodn/core-geonetwork/blob/2.10.x-imos-link-monitor-alg-change/web/src/main/java/org/fao/geonet/monitor/link/LinkInfo.java#L47

In a nutshell, it's much simpler since don't return `UNKNOWN` if there are not enough checks, we calculate anyway and compare to `percentWorking`.