### PR TITLE
Display temporal resolution codes for facet values

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/search/facet/DimensionFormatter.java
+++ b/web/src/main/java/org/fao/geonet/kernel/search/facet/DimensionFormatter.java
@@ -47,10 +47,22 @@ public class DimensionFormatter implements Formatter {
 
 	@Override
 	public Element buildCategoryTag(String value, String count, String langCode) {
+		String displayValue = getDisplayValue(value, langCode);
+
 		Element categoryTag = new Element("category");
-		Translator translator = config.getTranslator(context, langCode);
-		categoryTag.setAttribute("value", translator.translate(value));
+		categoryTag.setAttribute("value", value);
+
+		if (!displayValue.equals(value)) {
+			categoryTag.setAttribute("label", displayValue);
+		}
+
 		categoryTag.setAttribute("count", count);
 		return categoryTag;
+	}
+
+	private String getDisplayValue(String value, String langCode) {
+		Translator translator = config.getTranslator(context, langCode);
+		String displayValue = translator.translate(value);
+		return displayValue == null ? value : displayValue;
 	}
 }

--- a/web/src/test/java/org/fao/geonet/kernel/search/facet/DimensionFormatterTest.java
+++ b/web/src/test/java/org/fao/geonet/kernel/search/facet/DimensionFormatterTest.java
@@ -24,7 +24,12 @@ public class DimensionFormatterTest {
 
 		ItemConfig mockConfig = mock(ItemConfig.class);
 		when(mockConfig.getDimension()).thenReturn(mockDimension);
-		when(mockConfig.getTranslator(null, "eng")).thenReturn(Translator.NULL_TRANSLATOR);
+
+		when(mockConfig.getTranslator(null, "eng")).thenReturn(new Translator() {
+			public String translate(String key) {
+				return key.equals("six-day") ? "Six day" : key; 
+			}
+		});
 
 		formatter = new DimensionFormatter(null, mockConfig);
 	}
@@ -48,6 +53,18 @@ public class DimensionFormatterTest {
 		assertEquals(0, categoryTag.getContent().size());
 		assertEquals(2, categoryTag.getAttributes().size());
 		assertEquals("oceans", categoryTag.getAttributeValue("value"));
+		assertEquals("3", categoryTag.getAttributeValue("count"));
+	}
+
+	@Test
+	public void testBuildTranslatedCategoryTag() {
+		Element categoryTag = formatter.buildCategoryTag("six-day", "3", "eng");
+
+		assertEquals("category", categoryTag.getName());
+		assertEquals(0, categoryTag.getContent().size());
+		assertEquals(3, categoryTag.getAttributes().size());
+		assertEquals("six-day", categoryTag.getAttributeValue("value"));
+		assertEquals("Six day", categoryTag.getAttributeValue("label"));
 		assertEquals("3", categoryTag.getAttributeValue("count"));
 	}
 


### PR DESCRIPTION
Display codes for temporal resolution for now.  Enable display of translated values later

Fixes issue where clicking on the facet value didn't find any records