### PR TITLE
Only index resource constraints and only index each one once.

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
@@ -313,16 +313,16 @@
 			<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 			
 			<xsl:for-each select="gmd:resourceConstraints">
-				<xsl:for-each select="//gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue">
+				<xsl:for-each select="*/gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue">
 					<Field name="accessConstr" string="{string(.)}" store="true" index="true"/>
 				</xsl:for-each>
-				<xsl:for-each select="//gmd:otherConstraints/gco:CharacterString">
+				<xsl:for-each select="*/gmd:otherConstraints/gco:CharacterString">
 					<Field name="otherConstr" string="{string(.)}" store="true" index="true"/>
 				</xsl:for-each>
-				<xsl:for-each select="//gmd:classification/gmd:MD_ClassificationCode/@codeListValue">
+				<xsl:for-each select="*/gmd:classification/gmd:MD_ClassificationCode/@codeListValue">
 					<Field name="classif" string="{string(.)}" store="true" index="true"/>
 				</xsl:for-each>
-				<xsl:for-each select="//gmd:useLimitation/gco:CharacterString">
+				<xsl:for-each select="*/gmd:useLimitation/gco:CharacterString">
 					<Field name="conditionApplyingToAccessAndUse" string="{string(.)}" store="true" index="true"/>
 				</xsl:for-each>
 			</xsl:for-each>


### PR DESCRIPTION
The // here was picking up all constraints including metadata constraints for each gmd:resourceConstraints in the metadata.