### PR TITLE
Add imageLink to lucene dumpFields

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-lucene.xml
+++ b/web/src/main/webapp/WEB-INF/config-lucene.xml
@@ -141,6 +141,7 @@
       <field name="jurisdictionLink" tagName="jurisdictionLink" />
       <field name="licenseLink" tagName="licenseLink" />
       <field name="licenseName" tagName="licenseName" />
+      <field name="imageLink" tagName="imageLink" />
       <field name="attrConstr" tagName="attrConstr" />
       <field name="otherCitation" tagName="otherCitation" />
       <field name="useLimitation" tagName="useLimitation" />


### PR DESCRIPTION
Depends on aodn/schema-plugins#31

Licence metadata often includes a link to an image logo, which we can use to display in the portal's download-confirmation window.