### PR TITLE
Make online resource monitor logging more informative…

### DIFF
--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
@@ -113,12 +113,12 @@ public class MetadataRecordInfo {
 
         logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'", uuid, title, prevStatus, newStatus));
 
-        if (newStatus == OnlineResourceMonitorService.Status.FAILED) {
-            for (final OnlineResourceInfo onlineResourceInfo : onlineResourceInfoList) {
-                if (onlineResourceInfo.getStatus() != OnlineResourceMonitorService.Status.WORKING) {
-                    logger.info(String.format("Link for uuid='%s', title='%s', '%s' is in state '%s'", uuid, title, onlineResourceInfo.toString(), onlineResourceInfo.getStatus()));
-                }
-            }
+        for (final OnlineResourceInfo onlineResourceInfo : onlineResourceInfoList) {
+            logger.debug(String.format(
+                "Link for uuid='%s', title='%s', '%s' is in state '%s': %d of last %d checks failed",
+                uuid, title, onlineResourceInfo.toString(), onlineResourceInfo.getStatus(),
+                onlineResourceInfo.getFailureCount(), onlineResourceInfo.getCheckCount()
+            ));
         }
     }
 

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceInfo.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceInfo.java
@@ -22,6 +22,18 @@ public class OnlineResourceInfo {
         return checkInfoList.size();
     }
 
+    public int getFailureCount() {
+        int failedCount = 0;
+
+        for (final CheckInfo checkInfo : checkInfoList) {
+            if (!checkInfo.status) {
+                failedCount++;
+            }
+        }
+
+        return failedCount;
+    }
+
     private boolean isFresh() {
         long now = System.currentTimeMillis() / 1000l;
         long lastCheck = checkInfoList.get(getCheckCount() - 1).timestamp;
@@ -38,21 +50,9 @@ public class OnlineResourceInfo {
     }
 
     private boolean failureRateAcceptable() {
-        double checkFailureRate = checkFailureCount() / (double) OnlineResourceMonitorService.maxChecks;
+        double checkFailureRate = getFailureCount() / (double) OnlineResourceMonitorService.maxChecks;
 
         return checkFailureRate <= OnlineResourceMonitorService.maxFailureRate;
-    }
-
-    private int checkFailureCount() {
-        int failedCount = 0;
-
-        for (final CheckInfo checkInfo : checkInfoList) {
-            if (!checkInfo.status) {
-                failedCount++;
-            }
-        }
-
-        return failedCount;
     }
 
     public OnlineResourceMonitorService.Status evaluateStatus() {

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
@@ -93,8 +93,7 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
                 logger.info(String.format("You might want to tune '%s'", Geonet.Config.ONLINE_RESOURCE_MONITOR_FIXEDDELAYSECONDS));
             }
         } catch(Throwable e) {
-            logger.error("Link Monitor error: " + e.getMessage() + " This error is ignored.");
-            logger.info(e);
+            logger.error("Online Resource Monitor error: " + e + " This error is ignored.", e);
         } finally {
             lock.unlock();
         }
@@ -108,8 +107,9 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
         try {
             return getAllRecordsLucene();
         } catch (Exception e) {
-            logger.info(e);
+            logger.error(e,e);
         }
+
         return new HashMap<String, MetadataRecordInfo>();
     }
 
@@ -142,7 +142,7 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
                 }
             }
         } catch (Exception e) {
-            logger.info(e);
+            logger.error(e,e);
         } finally {
             geonetContext.getSearchmanager().releaseIndexReader(indexAndTaxonomy);
         }
@@ -156,7 +156,7 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
             String id = geonetContext.getDataManager().getMetadataId(dbms, uuid);
             return geonetContext.getDataManager().getMetadataIgnorePermissions(dbms, id);
         } catch (Exception e) {
-            logger.info(e);
+            logger.error(e,e);
         }
         return null;
     }
@@ -213,7 +213,7 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
             try {
                 Thread.sleep(betweenChecksIntervalMs);
             } catch (InterruptedException e) {
-                logger.info(e);
+                logger.error(e,e);
             }
         }
     }


### PR DESCRIPTION
Print stack traces; In debug mode show the number of checks failed out of total checks for each layer. 
Hopefully the stacktraces help if/when https://github.com/aodn/issues/issues/62 happens again and hopefully the check logging will help in analysing the flapping layers of https://github.com/aodn/issues/issues/63