### PR TITLE
Online resources check filters new requirements

### DIFF
--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWmsFilters.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWmsFilters.java
@@ -90,6 +90,10 @@ public class OnlineResourceCheckerWmsFilters extends OnlineResourceCheckerDefaul
             Document doc = parseXML(is);
             NodeList descNodes = doc.getElementsByTagName("name");
 
+            if (descNodes.getLength() == 0) {
+                throw new Exception(String.format("Filter count is zero uuid='%s' URL= %s",this.uuid, this.url));
+            }
+
             for (int i = 0; i < descNodes.getLength(); i++) {
                 String property = descNodes.item(i).getTextContent();
                 if (!checkFilterValues(getFilterValuesUrl(property))) {

--- a/web/src/main/webapp/WEB-INF/classes/JZkitApplicationContext.xml
+++ b/web/src/main/webapp/WEB-INF/classes/JZkitApplicationContext.xml
@@ -51,7 +51,7 @@
   <bean id="OnlineResourceCheckerWmsFilters" class="org.fao.geonet.monitor.onlineresource.OnlineResourceCheckerWmsFilters">
     <property name="onlineResourceTypes">
       <set>
-        <value>OGC:WMS-1.1.1-http-get-map</value>
+        <value>AODN:FILTERS--enabled</value>
       </set>
     </property>
   </bean>


### PR DESCRIPTION
If the new onlineResource of `AODN:FILTERS--enabled` is present in a metadata record, then there is the expectation that there must be one or more filter that can be checked.