### PR TITLE
Fixes aodn/issues#124

### DIFF
--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
@@ -193,7 +193,7 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
         }
 
         for (Map.Entry<String, MetadataRecordInfo> record : recordMap.entrySet()) {
-            String title = records.get(record.getKey()).getTitle();
+            String title = record.getValue().getTitle();
             if (! records.containsKey(record.getKey())) {
                 // Record was deleted
                 logger.info(String.format("Deleting metadata record title=%s uuid=%s ", title, record.getKey()));


### PR DESCRIPTION
Deleting a record effectively stopped any online resource checking from happening as reindexing
then failed everytime it tried to lookup the title on the missing record in the index.

Use the title from the previously stored information for the record used to identify that the record
has been deleted instead.