### PR TITLE
Issue637 fix

### DIFF
--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/CheckInfo.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/CheckInfo.java
@@ -1,11 +1,29 @@
 package org.fao.geonet.monitor.onlineresource;
 
 public class CheckInfo {
-    public boolean status;
-    public long timestamp;
+
+    private CheckResult checkResult;
+    private long timestamp;
 
     public CheckInfo(OnlineResourceCheckerInterface onlineResourceChecker) {
-        this.status = onlineResourceChecker.check();
+        this.checkResult = onlineResourceChecker.check();
         this.timestamp = System.currentTimeMillis() / 1000l;
     }
+
+    public CheckResult getCheckResult() {
+        return checkResult;
+    }
+
+    public void setCheckResult(CheckResult checkResult) {
+        this.checkResult = checkResult;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
 }

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/CheckResult.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/CheckResult.java
@@ -1,0 +1,29 @@
+package org.fao.geonet.monitor.onlineresource;
+
+public class CheckResult {
+
+    private boolean isSuccessful;
+
+    private String resultReason;
+
+    public CheckResult(boolean isSuccessful, String resultReason) {
+        this.isSuccessful = isSuccessful;
+        this.resultReason = resultReason;
+    }
+
+    public boolean isSuccessful() {
+        return isSuccessful;
+    }
+
+    public void setIsSuccessful(boolean isSuccessful) {
+        this.isSuccessful = isSuccessful;
+    }
+
+    public String getResultReason() {
+        return resultReason;
+    }
+
+    public void setResultReason(String resultReason) {
+        this.resultReason = resultReason;
+    }
+}

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
@@ -114,6 +114,13 @@ public class MetadataRecordInfo {
         //  Get a list of the error messages to report (if any)
         StringBuilder errorSummary = new StringBuilder();
         for (final OnlineResourceInfo onlineResourceInfo : onlineResourceInfoList) {
+
+            logger.debug(String.format(
+                    "Link for uuid='%s', title='%s', '%s' is in state '%s': %d of last %d checks failed",
+                    uuid, title, onlineResourceInfo.toString(), onlineResourceInfo.getStatus(),
+                    onlineResourceInfo.getFailureCount(), onlineResourceInfo.getCheckCount()
+            ));
+
             if(onlineResourceInfo.getCheckInfoList() != null) {
                 List<CheckInfo> infoList = onlineResourceInfo.getCheckInfoList();
                 for(CheckInfo currentCheckInfo : infoList) {
@@ -132,14 +139,6 @@ public class MetadataRecordInfo {
             logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'. Reason/s: %s", uuid, title, prevStatus, newStatus, errorString));
         } else {
             logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'", uuid, title, prevStatus, newStatus));
-        }
-
-        for (final OnlineResourceInfo onlineResourceInfo : onlineResourceInfoList) {
-            logger.debug(String.format(
-                "Link for uuid='%s', title='%s', '%s' is in state '%s': %d of last %d checks failed",
-                uuid, title, onlineResourceInfo.toString(), onlineResourceInfo.getStatus(),
-                onlineResourceInfo.getFailureCount(), onlineResourceInfo.getCheckCount()
-            ));
         }
     }
 

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
@@ -136,7 +136,7 @@ public class MetadataRecordInfo {
 
         String errorString = errorSummary.toString();
         if(errorString.trim().length() > 0) {
-            logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'. Reason/s: %s", uuid, title, prevStatus, newStatus, errorString));
+            logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'. reason=%s", uuid, title, prevStatus, newStatus, errorString));
         } else {
             logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'", uuid, title, prevStatus, newStatus));
         }

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
@@ -136,7 +136,7 @@ public class MetadataRecordInfo {
 
         String errorString = errorSummary.toString();
         if(errorString.trim().length() > 0) {
-            logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'. reason=%s", uuid, title, prevStatus, newStatus, errorString));
+            logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'. Reason/s= %s", uuid, title, prevStatus, newStatus, errorString));
         } else {
             logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'", uuid, title, prevStatus, newStatus));
         }

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/MetadataRecordInfo.java
@@ -111,7 +111,28 @@ public class MetadataRecordInfo {
             return;
         }
 
-        logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'", uuid, title, prevStatus, newStatus));
+        //  Get a list of the error messages to report (if any)
+        StringBuilder errorSummary = new StringBuilder();
+        for (final OnlineResourceInfo onlineResourceInfo : onlineResourceInfoList) {
+            if(onlineResourceInfo.getCheckInfoList() != null) {
+                List<CheckInfo> infoList = onlineResourceInfo.getCheckInfoList();
+                for(CheckInfo currentCheckInfo : infoList) {
+                    CheckResult checkResult = currentCheckInfo.getCheckResult();
+                    if(!checkResult.isSuccessful()) {
+                        if(checkResult.getResultReason() != null) {
+                            errorSummary.append("[" + checkResult.getResultReason() + "] ");
+                        }
+                    }
+                }
+            }
+        }
+
+        String errorString = errorSummary.toString();
+        if(errorString.trim().length() > 0) {
+            logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'. Reason/s: %s", uuid, title, prevStatus, newStatus, errorString));
+        } else {
+            logger.info(String.format("Record uuid='%s' title='%s' changes status from '%s' to '%s'", uuid, title, prevStatus, newStatus));
+        }
 
         for (final OnlineResourceInfo onlineResourceInfo : onlineResourceInfoList) {
             logger.debug(String.format(

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerDefault.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerDefault.java
@@ -27,7 +27,7 @@ public class OnlineResourceCheckerDefault implements OnlineResourceCheckerInterf
     }
 
     @Override
-    public boolean check() {
+    public CheckResult check() {
         return OnlineResourceCheckerUtils.checkHttpUrl(this.uuid, this.url);
     }
 

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerInterface.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerInterface.java
@@ -7,7 +7,7 @@ public interface OnlineResourceCheckerInterface {
 
     public boolean canHandle(String onlineResourceType);
 
-    public boolean check();
+    public CheckResult check();
 
     public String toString();
 }

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerUtils.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerUtils.java
@@ -21,7 +21,7 @@ public class OnlineResourceCheckerUtils {
     public static String NAME_XPATH = "gmd:name";
     private static Logger logger = Logger.getLogger(OnlineResourceCheckerUtils.class);
 
-    public static boolean checkHttpUrl(String uuid, String url) {
+    public static CheckResult checkHttpUrl(String uuid, String url) {
         try {
             HttpURLConnection connection;
             connection = (HttpURLConnection) (new URL(url)).openConnection();
@@ -32,15 +32,17 @@ public class OnlineResourceCheckerUtils {
 
             logger.debug(String.format("%s -> %d", url, connection.getResponseCode()));
             if (connection.getResponseCode() != 200) {
-                logger.info(String.format("link broken uuid='%s', url='%s', error='bad response code %d'", uuid, url, connection.getResponseCode()));
+                String errorMessage = String.format("link broken uuid='%s', url='%s', error='bad response code %d'", uuid, url, connection.getResponseCode());
+                logger.info(errorMessage);
+                return new CheckResult(false, errorMessage);
             } else {
-                return true;
+                return new CheckResult(true, null);
             }
         } catch (Exception e) {
-            logger.info(String.format("link broken uuid='%s', url='%s', error='%s', stack='%s'", uuid, url, e.getMessage(), exceptionToString(e)));
-            return false;
+            String errorMessage = String.format("link broken uuid='%s', url='%s', error='%s', stack='%s'", uuid, url, e.getMessage(), exceptionToString(e));
+            logger.info(errorMessage);
+            return new CheckResult(false, errorMessage);
         }
-        return false;
     }
 
     public static String parseOnlineResource(Element onlineResource, String path) {

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWfs.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWfs.java
@@ -22,7 +22,7 @@ public class OnlineResourceCheckerWfs extends OnlineResourceCheckerDefault {
     }
 
     @Override
-    public boolean check() {
+    public CheckResult check() {
         try {
             HttpURLConnection connection;
             connection = (HttpURLConnection) (new URL(url)).openConnection();
@@ -34,9 +34,10 @@ public class OnlineResourceCheckerWfs extends OnlineResourceCheckerDefault {
             logger.debug(String.format("%s -> %d", url, connection.getResponseCode()));
 
             if (connection.getResponseCode() != 200) {
-                logger.info(String.format("WFS GetFeature link broken for uuid='%s', url='%s', error='bad response code %d'",
-                        this.uuid, this.url, connection.getResponseCode()));
-                return false;
+                String errorMessage = String.format("WFS GetFeature link broken for uuid='%s', url='%s', error='bad response code %d'",
+                        this.uuid, this.url, connection.getResponseCode());
+                logger.info(errorMessage);
+                return new CheckResult(false, errorMessage);
             }
 
             // text/xml; subtype=gml/2.1.2
@@ -50,12 +51,13 @@ public class OnlineResourceCheckerWfs extends OnlineResourceCheckerDefault {
                     if (e.getTagName().equals("wfs:FeatureCollection")
                         && ((Element)e.getFirstChild().getNextSibling()).getTagName().equals("gml:featureMember")) {
                         // ok
-                        return true;
+                        return new CheckResult(true, null);
                     } else {
-                        logger.info(String.format(
+                        String errorMessage = String.format(
                                 "WFS GetFeature request does not return a FeatureCollection for uuid='%s', url='%s', error='wfs response not recognized'",
-                                this.uuid, this.url));
-                        return false;
+                                this.uuid, this.url);
+                        logger.info(errorMessage);
+                        return new CheckResult(false, errorMessage);
                     }
                 } finally {
                     if (is != null) {
@@ -63,17 +65,19 @@ public class OnlineResourceCheckerWfs extends OnlineResourceCheckerDefault {
                     }
                 }
             } else {
-                logger.info(String.format(
+                String errorMessage = String.format(
                         "WFS GetFeature request returns non-xml content for uuid='%s', url='%s', error='unexpected content-type %s'",
-                        this.uuid, this.url, connection.getContentType()));
-                return false;
+                        this.uuid, this.url, connection.getContentType());
+                logger.info(errorMessage);
+                return new CheckResult(false, errorMessage);
             }
 
         } catch (Exception e) {
-            logger.info(String.format(
+            String errorMessage = String.format(
                     "WFS GetFeature request results in exception for uuid='%s', url='%s', error='%s' stack='%s'",
-                    this.uuid, url, e.getMessage(), OnlineResourceCheckerUtils.exceptionToString(e)));
-            return false;
+                    this.uuid, url, e.getMessage(), OnlineResourceCheckerUtils.exceptionToString(e));
+            logger.info(errorMessage);
+            return new CheckResult(false, errorMessage);
         }
     }
 }

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWmsFilters.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWmsFilters.java
@@ -71,7 +71,7 @@ public class OnlineResourceCheckerWmsFilters extends OnlineResourceCheckerDefaul
     }
 
     @Override
-    public boolean check() {
+    public CheckResult check() {
 
         InputStream is = null;
         boolean check = true;
@@ -81,9 +81,10 @@ public class OnlineResourceCheckerWmsFilters extends OnlineResourceCheckerDefaul
             HttpURLConnection connection = getConnection(this.url);
 
             if (connection.getResponseCode() != 200) {
-                logger.info(String.format("link broken uuid='%s', url='%s', error='bad response code %d'",
-                        this.uuid, this.url, connection.getResponseCode()));
-                return false;
+                String errorMessage = String.format("link broken uuid='%s', url='%s', error='bad response code %d'",
+                        this.uuid, this.url, connection.getResponseCode());
+                logger.info(errorMessage);
+                return new CheckResult(false, errorMessage);
             }
 
             is = connection.getInputStream();
@@ -100,11 +101,13 @@ public class OnlineResourceCheckerWmsFilters extends OnlineResourceCheckerDefaul
                     throw new Exception(String.format("Filter '%s' not working. URL= %s",property, getFilterValuesUrl(property)));
                 }
             }
+            return new CheckResult(true, null);
         }
         catch (Exception e) {
-            logger.info(String.format("link broken uuid='%s', url='%s', error='%s'",
-                    this.uuid, this.url, e.getMessage()));
-            check = false;
+            String errorMessage = String.format("link broken uuid='%s', url='%s', error='%s'",
+                    this.uuid, this.url, e.getMessage());
+            logger.info(errorMessage);
+            return new CheckResult(false, errorMessage);
         }
         finally {
             if (is != null) {
@@ -112,15 +115,15 @@ public class OnlineResourceCheckerWmsFilters extends OnlineResourceCheckerDefaul
                     is.close();
                 }
                 catch (IOException e) {
-                    logger.info(String.format("link broken uuid='%s', url='%s', error='%s'",
-                            this.uuid, this.url, e.getMessage()));
-                    check = false;
+                    String errorMessage = String.format("link broken uuid='%s', url='%s', error='%s'",
+                            this.uuid, this.url, e.getMessage());
+                    logger.info(errorMessage);
+                    return new CheckResult(false, errorMessage);
                 }
             }
             logger.info(String.format("link uuid='%s', url='%s', took '%s' seconds",
                     this.uuid, this.url, (System.currentTimeMillis() - start) / 1000));
 
         }
-        return check;
     }
 }

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWmsGetCapabilities.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWmsGetCapabilities.java
@@ -19,11 +19,10 @@ public class OnlineResourceCheckerWmsGetCapabilities extends OnlineResourceCheck
     }
 
     @Override
-    public boolean check() {
+    public CheckResult check() {
 
         InputStream is = null;
         HttpURLConnection connection;
-        boolean check = true;
         long start = System.currentTimeMillis();
 
         try {
@@ -36,31 +35,33 @@ public class OnlineResourceCheckerWmsGetCapabilities extends OnlineResourceCheck
             logger.debug(String.format("%s -> %d", url, connection.getResponseCode()));
 
             if(connection.getResponseCode() != 200) {
-                logger.info(String.format("link broken uuid='%s', url='%s', error='bad response code %d'",
-                        this.uuid, this.url, connection.getResponseCode()));
-                check = false;
+                String errorMessage = String.format("link broken uuid='%s', url='%s', error='bad response code %d'",
+                        this.uuid, this.url, connection.getResponseCode());
+                logger.info(errorMessage);
+                return new CheckResult(false, errorMessage);
             } else {
                 is = connection.getInputStream();
                 OnlineResourceCheckerUtils.parseXML(is);
+                return new CheckResult(true, null);
             }
         } catch (Exception e) {
-            logger.info(String.format("link broken uuid='%s', url='%s', error='%s' stack='%s'",
-                    uuid, url, e.getMessage(), OnlineResourceCheckerUtils.exceptionToString(e)));
-            check = false;
+            String errorMessage = String.format("link broken uuid='%s', url='%s', error='%s' stack='%s'",
+                    uuid, url, e.getMessage(), OnlineResourceCheckerUtils.exceptionToString(e));
+            logger.info(errorMessage);
+            return new CheckResult(false, errorMessage);
         } finally {
             if(is != null) {
                 try {
                     is.close();
                 } catch (IOException e) {
-                    logger.info(String.format("link broken uuid='%s', url='%s', error='%s' stack='%s'",
-                            uuid, url, e.getMessage(), OnlineResourceCheckerUtils.exceptionToString(e)));
-                    check = false;
+                    String errorMessage = String.format("link broken uuid='%s', url='%s', error='%s' stack='%s'",
+                            uuid, url, e.getMessage(), OnlineResourceCheckerUtils.exceptionToString(e));
+                    logger.info(errorMessage);
+                    return new CheckResult(false, errorMessage);
                 }
             }
             logger.info(String.format("link uuid='%s', url='%s', took '%s' seconds",
                     uuid, url, (System.currentTimeMillis() - start) / 1000));
         }
-
-        return check;
     }
 }

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWps.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWps.java
@@ -34,7 +34,7 @@ public class OnlineResourceCheckerWps extends OnlineResourceCheckerDefault {
 
             // If the wfs request fails or returns csv without time value
             if (time == null)
-                return new CheckResult(false, "No time value passed.");
+                return new CheckResult(false, "No time value found for layer.");
 
             String requestXml = getRequestXml(time);
 

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWps.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceCheckerWps.java
@@ -27,14 +27,14 @@ public class OnlineResourceCheckerWps extends OnlineResourceCheckerDefault {
     }
 
     @Override
-    public boolean check() {
+    public CheckResult check() {
         long start = System.currentTimeMillis();
         try {
             String time = getTime();
 
             // If the wfs request fails or returns csv without time value
             if (time == null)
-                return false;
+                return new CheckResult(false, "No time value passed.");
 
             String requestXml = getRequestXml(time);
 
@@ -62,9 +62,10 @@ public class OnlineResourceCheckerWps extends OnlineResourceCheckerDefault {
             logger.debug(String.format("%s -> %d", url, connection.getResponseCode()));
 
             if (connection.getResponseCode() != 200) {
-                logger.info(String.format("link broken uuid='%s', url='%s', error='bad response code %d'",
-                        this.uuid, this.url, connection.getResponseCode()));
-                return false;
+                String errorMessage = String.format("link broken uuid='%s', url='%s', error='bad response code %d'",
+                        this.uuid, this.url, connection.getResponseCode());
+                logger.info(errorMessage);
+                return new CheckResult(false, errorMessage);
             }
 
             // Checking if file is readable
@@ -75,28 +76,31 @@ public class OnlineResourceCheckerWps extends OnlineResourceCheckerDefault {
                     is = connection.getInputStream();
                     reader = new CSVReader(new InputStreamReader(connection.getInputStream()));
                     if (reader.readNext() == null) {
-                        logger.info(String.format("link broken uuid='%s', url='%s', error='empty row data in csv file'", this.uuid, this.url));
-                        return false;
+                        String errorMessage = String.format("link broken uuid='%s', url='%s', error='empty row data in csv file'", this.uuid, this.url);
+                        logger.info(errorMessage);
+                        return new CheckResult(false, errorMessage);
                     }
                 } finally {
                     if (is != null) {
                         is.close();
                     }
                 }
-                return true;
+                return new CheckResult(true, null);
             } else {
-                logger.info(String.format("link broken uuid='%s', url='%s', error='unexpected content-type'", this.uuid, this.url));
+                String errorMessage = String.format("link broken uuid='%s', url='%s', error='unexpected content-type'", this.uuid, this.url);
+                logger.info(errorMessage);
+                return new CheckResult(false, errorMessage);
             }
 
         } catch (Exception e) {
-            logger.info(String.format("link broken uuid='%s', url='%s', error='%s' stack='%s'",
-                    uuid, url, e.getMessage(), OnlineResourceCheckerUtils.exceptionToString(e)));
+            String errorMessage = String.format("link broken uuid='%s', url='%s', error='%s' stack='%s'",
+                    uuid, url, e.getMessage(), OnlineResourceCheckerUtils.exceptionToString(e));
+            logger.info(errorMessage);
+            return new CheckResult(false, errorMessage);
         } finally {
             logger.info(String.format("link uuid='%s', url='%s', took '%s' seconds",
                     uuid, url, (System.currentTimeMillis() - start) / 1000));
         }
-
-        return false;
     }
 
     private String getRequestXml(String time) {

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceInfo.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceInfo.java
@@ -40,7 +40,7 @@ public class OnlineResourceInfo {
 
     private boolean isFresh() {
         long now = System.currentTimeMillis() / 1000l;
-        long lastCheck = checkInfoList.get(getCheckCount() - 1).timestamp;
+        long lastCheck = checkInfoList.get(getCheckCount() - 1).getTimestamp();
         if (now - lastCheck > OnlineResourceMonitorService.freshness) {
             logger.debug(String.format("Last test is too old, ('%s' seconds ago)", now - lastCheck));
             return false;

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceInfo.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceInfo.java
@@ -7,6 +7,10 @@ import java.util.List;
 public class OnlineResourceInfo {
     private static Logger logger = Logger.getLogger(OnlineResourceInfo.class);
 
+    public List<CheckInfo> getCheckInfoList() {
+        return checkInfoList;
+    }
+
     private List<CheckInfo> checkInfoList;
 
     private final OnlineResourceCheckerInterface onlineResourceChecker;
@@ -26,7 +30,7 @@ public class OnlineResourceInfo {
         int failedCount = 0;
 
         for (final CheckInfo checkInfo : checkInfoList) {
-            if (!checkInfo.status) {
+            if (!checkInfo.getCheckResult().isSuccessful()) {
                 failedCount++;
             }
         }

--- a/web/src/test/java/org/fao/geonet/monitor/onlineresource/OnlineResourceInfoTest.java
+++ b/web/src/test/java/org/fao/geonet/monitor/onlineresource/OnlineResourceInfoTest.java
@@ -3,10 +3,12 @@ package org.fao.geonet.monitor.onlineresource;
 import org.fao.geonet.test.TestCase;
 import org.jdom.Element;
 
+import java.util.List;
+
 import static org.fao.geonet.monitor.onlineresource.OnlineResourceMonitorService.Status.*;
 
 public class OnlineResourceInfoTest extends TestCase {
-    public static boolean testResult = true;
+    public static CheckResult testResult = new CheckResult(true, null);
 
     public class OnlineResourceCheckerMock implements OnlineResourceCheckerInterface {
         public OnlineResourceCheckerMock() {}
@@ -15,7 +17,7 @@ public class OnlineResourceInfoTest extends TestCase {
         public void setOnlineResource(String uuid, final Element onlineResource) {}
 
         @Override
-        public boolean check() {
+        public CheckResult check() {
             return testResult;
         }
 
@@ -73,6 +75,15 @@ public class OnlineResourceInfoTest extends TestCase {
         attemptChecks(3, 3);
 
         assertEquals(FAILED, onlineResourceInfo.getStatus());
+
+        // Check that error messages are being passed in the CheckResult object for
+        // failures
+        List<CheckInfo> checkInfoList = onlineResourceInfo.getCheckInfoList();
+        for(CheckInfo check : checkInfoList) {
+            if(!check.getCheckResult().isSuccessful()) {
+                assertTrue(check.getCheckResult().getResultReason() != null);
+            }
+        }
     }
 
     public void testGetStatusNoChecks() throws Exception {
@@ -90,12 +101,12 @@ public class OnlineResourceInfoTest extends TestCase {
     private void attemptChecks(int numberOfChecks, int numberOfFailures) {
         int numberOfSuccesses = numberOfChecks - numberOfFailures;
 
-        testResult = true;
+        testResult = new CheckResult(true, null);
         for (int i = 0; i < numberOfSuccesses; i++) {
             onlineResourceInfo.check();
         }
 
-        testResult = false;
+        testResult = new CheckResult(false, "Test failure message");
         for (int i = 0; i < numberOfFailures; i++) {
             onlineResourceInfo.check();
         }


### PR DESCRIPTION
Changed CheckInfo to pass back a CheckResult instead of a boolean to indicate the success/failure of the check.  CheckResult has a resultReason field which can be used to pass back the error message if the check fails.  All resultReasons for failed checks are logged when the state of the collection changes to FAILED.