### PR TITLE
catch all exceptions in ORM and log

### DIFF
--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
@@ -101,17 +101,22 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
 
     @Override
     public void run() {
+        logger.info("Starting Online Resource Monitor thread");
         try {
-            if (lock.tryLock()) {
-                check();
-            } else {
-                logger.info("Check is already in progress, skipping...");
-                logger.info(String.format("You might want to tune '%s'", Geonet.Config.ONLINE_RESOURCE_MONITOR_FIXEDDELAYSECONDS));
+            try {
+                if (lock.tryLock()) {
+                    check();
+                } else {
+                    logger.info("Check is already in progress, skipping...");
+                    logger.info(String.format("You might want to tune '%s'", Geonet.Config.ONLINE_RESOURCE_MONITOR_FIXEDDELAYSECONDS));
+                }
+            } catch (Throwable e) {
+                logger.error("Online Resource Monitor error: " + e + " This error is ignored.", e);
+            } finally {
+                lock.unlock();
             }
-        } catch(Throwable e) {
-            logger.error("Online Resource Monitor error: " + e + " This error is ignored.", e);
-        } finally {
-            lock.unlock();
+        } catch (Exception e) {
+            logger.error("Failed to run resource check. Online Resource Monitor may terminate:" + e, e);
         }
     }
 

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
@@ -115,7 +115,7 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
             } finally {
                 lock.unlock();
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             logger.error("Failed to run resource check. Online Resource Monitor may terminate:" + e, e);
         }
     }

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
@@ -101,19 +101,20 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
 
     @Override
     public void run() {
-        logger.info("Starting Online Resource Monitor thread");
         try {
-            try {
-                if (lock.tryLock()) {
+            if (lock.tryLock()) {  // If not locked by another thread increment hold count, return true
+                try {
                     check();
-                } else {
-                    logger.info("Check is already in progress, skipping...");
-                    logger.info(String.format("You might want to tune '%s'", Geonet.Config.ONLINE_RESOURCE_MONITOR_FIXEDDELAYSECONDS));
+                } catch (Throwable e) {
+                    logger.error("Online Resource Monitor error: " + e + " This error is ignored.", e);
+                } finally {
+                    // If this thread has the lock, decrement hold count and release lock when count is 0.
+                    // If this thread does not have the lock throw IllegalMonitorStateException
+                    lock.unlock();
                 }
-            } catch (Throwable e) {
-                logger.error("Online Resource Monitor error: " + e + " This error is ignored.", e);
-            } finally {
-                lock.unlock();
+            } else {
+                logger.warn("Check is already in progress, skipping...");
+                logger.warn(String.format("You might want to tune '%s'", Geonet.Config.ONLINE_RESOURCE_MONITOR_FIXEDDELAYSECONDS));
             }
         } catch (Throwable e) {
             logger.error("Failed to run resource check. Online Resource Monitor may terminate:" + e, e);


### PR DESCRIPTION
ORM is a  ScheduledExecutorService

If any execution of the task encounters an exception, subsequent executions are suppressed. Otherwise, the task will only terminate via cancellation or termination of the executor.

This will catch exceptions and thus allow the ORM to restart next time around.  We may modify this again later once we understand what exception is being thrown that occaisionally stops the ORM.