### PR TITLE
Use scheduled future

### DIFF
--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -625,8 +625,8 @@ public class Geonetwork implements ApplicationHandler {
 		final ScheduledFuture<?> future = scheduledExecutorService.scheduleWithFixedDelay(gc.getOnlineResourceMonitor(), onlineResourceMonitorInitialDelay, onlineResourceMonitorFixedDelay, TimeUnit.SECONDS);
 
 		scheduledExecutorService.execute(new Runnable() {
-			@Override
-			public void run() {
+		@Override
+		public void run() {
 				try {
 					future.get();
 				} catch (InterruptedException e) {

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -622,30 +622,30 @@ public class Geonetwork implements ApplicationHandler {
         }
 
         ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(2);
-		final ScheduledFuture<?> future = scheduledExecutorService.scheduleWithFixedDelay(gc.getOnlineResourceMonitor(), onlineResourceMonitorInitialDelay, onlineResourceMonitorFixedDelay, TimeUnit.SECONDS);
+        final ScheduledFuture<?> future = scheduledExecutorService.scheduleWithFixedDelay(gc.getOnlineResourceMonitor(), onlineResourceMonitorInitialDelay, onlineResourceMonitorFixedDelay, TimeUnit.SECONDS);
 
-		scheduledExecutorService.execute(new Runnable() {
-		@Override
-		public void run() {
-				try {
-					future.get();
-				} catch (InterruptedException e) {
-					logger.error("Scheduled ORM execution was interrupted:" + e.getMessage());
-					e.printStackTrace();
-				} catch (CancellationException e) {
-					logger.error("Scheduled ORM execution was cancelled:" + e.getMessage());
-					e.printStackTrace();
-				} catch (ExecutionException e) {
-					logger.error("Uncaught exception in scheduled ORM execution:" + e.getMessage());
-					e.printStackTrace();
-				} catch (Throwable t) {
-					logger.error("Error or exception in scheduled ORM execution:" + t.getMessage());
-					t.printStackTrace();
-				} finally {
-					logger.error("Failed to run resource check. Online Resource Monitor may terminate");
-				}
-			}
-		});
+        scheduledExecutorService.execute(new Runnable() {
+        @Override
+        public void run() {
+            try {
+                    future.get();
+                } catch (InterruptedException e) {
+                    logger.error("Scheduled ORM execution was interrupted:" + e.getMessage());
+                    e.printStackTrace();
+                } catch (CancellationException e) {
+                    logger.error("Scheduled ORM execution was cancelled:" + e.getMessage());
+                    e.printStackTrace();
+                } catch (ExecutionException e) {
+                    logger.error("Uncaught exception in scheduled ORM execution:" + e.getMessage());
+                    e.printStackTrace();
+                } catch (Throwable t) {
+                    logger.error("Error or exception in scheduled ORM execution:" + t.getMessage());
+                    t.printStackTrace();
+                } finally {
+                    logger.error("Failed to run resource check. Online Resource Monitor may terminate");
+                }
+            }
+        });
     }
 
     /**

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -33,9 +33,7 @@ import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import javax.servlet.ServletContext;
 
@@ -623,8 +621,31 @@ public class Geonetwork implements ApplicationHandler {
             return;
         }
 
-        ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
-        scheduledExecutorService.scheduleWithFixedDelay(gc.getOnlineResourceMonitor(), onlineResourceMonitorInitialDelay, onlineResourceMonitorFixedDelay, TimeUnit.SECONDS);
+        ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(2);
+		final ScheduledFuture<?> future = scheduledExecutorService.scheduleWithFixedDelay(gc.getOnlineResourceMonitor(), onlineResourceMonitorInitialDelay, onlineResourceMonitorFixedDelay, TimeUnit.SECONDS);
+
+		scheduledExecutorService.execute(new Runnable() {
+			@Override
+			public void run() {
+				try {
+					future.get();
+				} catch (InterruptedException e) {
+					logger.error("Scheduled ORM execution was interrupted:" + e.getMessage());
+					e.printStackTrace();
+				} catch (CancellationException e) {
+					logger.error("Scheduled ORM execution was cancelled:" + e.getMessage());
+					e.printStackTrace();
+				} catch (ExecutionException e) {
+					logger.error("Uncaught exception in scheduled ORM execution:" + e.getMessage());
+					e.printStackTrace();
+				} catch (Throwable t) {
+					logger.error("Error or exception in scheduled ORM execution:" + t.getMessage());
+					t.printStackTrace();
+				} finally {
+					logger.error("Failed to run resource check. Online Resource Monitor may terminate");
+				}
+			}
+		});
     }
 
     /**

--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
@@ -101,23 +101,19 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
 
     @Override
     public void run() {
-        try {
-            if (lock.tryLock()) {  // If not locked by another thread increment hold count, return true
-                try {
-                    check();
-                } catch (Throwable e) {
-                    logger.error("Online Resource Monitor error: " + e + " This error is ignored.", e);
-                } finally {
-                    // If this thread has the lock, decrement hold count and release lock when count is 0.
-                    // If this thread does not have the lock throw IllegalMonitorStateException
-                    lock.unlock();
-                }
-            } else {
-                logger.warn("Check is already in progress, skipping...");
-                logger.warn(String.format("You might want to tune '%s'", Geonet.Config.ONLINE_RESOURCE_MONITOR_FIXEDDELAYSECONDS));
+        if (lock.tryLock()) {  // If not locked by another thread increment hold count, return true
+            try {
+                check();
+            } catch (Throwable e) {
+                logger.error("Online Resource Monitor error: " + e + " This error is ignored.", e);
+            } finally {
+                // If this thread has the lock, decrement hold count and release lock when count is 0.
+                // If this thread does not have the lock throw IllegalMonitorStateException
+                lock.unlock();
             }
-        } catch (Throwable e) {
-            logger.error("Failed to run resource check. Online Resource Monitor may terminate:" + e, e);
+        } else {
+            logger.warn("Check is already in progress, skipping...");
+            logger.warn(String.format("You might want to tune '%s'", Geonet.Config.ONLINE_RESOURCE_MONITOR_FIXEDDELAYSECONDS));
         }
     }
 


### PR DESCRIPTION
See: https://www.cosmocode.de/en/blog/schoenborn/2009-12/17-uncaught-exceptions-in-scheduled-tasks
Note that future.get() blocks the thread it runs in until an exception occurs (or ORM stops - which should be never)