### PR TITLE
Update the Geonetwork 2.10 19139 schema plugin to index 19115-3 records

### DIFF
--- a/web/src/main/java/au/org/emii/classifier/UriLabelClassifier.java
+++ b/web/src/main/java/au/org/emii/classifier/UriLabelClassifier.java
@@ -1,0 +1,43 @@
+package au.org.emii.classifier;
+
+import org.apache.log4j.Logger;
+import org.apache.lucene.facet.taxonomy.CategoryPath;
+import org.fao.geonet.kernel.ThesaurusFinder;
+import org.fao.geonet.kernel.search.classifier.Classifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.net.*;
+
+/**
+ * This class is used to determine the category paths (facets) to be indexed for an AODN term given its URI
+ */
+
+public class UriLabelClassifier implements Classifier  {
+    private static Logger logger = Logger.getLogger(UriLabelClassifier.class);
+
+    private final AodnThesaurus vocabularyThesaurus; // vocabulary in which the term is defined
+    private final AodnTermClassifier termClassifier; // classifier used to create CategoryPaths for a term
+    private final String indexKey; // classifier indexKey
+    private Classifier uriClassifier;
+    private Classifier labelClassifier;
+
+    public UriLabelClassifier(ThesaurusFinder thesaurusFinder, String vocabularyScheme, String classificationScheme, String indexKey) {
+        vocabularyThesaurus = new AodnThesaurus(thesaurusFinder.getThesaurusByConceptScheme(vocabularyScheme));
+        AodnThesaurus classificationThesaurus = new AodnThesaurus(thesaurusFinder.getThesaurusByConceptScheme(classificationScheme));
+        termClassifier = new AodnTermClassifier(vocabularyThesaurus, classificationThesaurus);
+        this.indexKey = indexKey;
+        this.uriClassifier = new UriClassifier(thesaurusFinder, vocabularyScheme, classificationScheme, null);
+        this.labelClassifier = new LabelClassifier(thesaurusFinder, vocabularyScheme, classificationScheme, null);
+    }
+
+    @Override
+    public List<CategoryPath> classify(String value) {
+        try {
+            URL url = new URL(value);
+            return uriClassifier.classify(value);
+        } catch (MalformedURLException e){
+            return labelClassifier.classify(value);
+        }
+    }
+}

--- a/web/src/main/java/au/org/emii/classifier/UriLabelClassifier.java
+++ b/web/src/main/java/au/org/emii/classifier/UriLabelClassifier.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.net.*;
 
 /**
- * This class is used to determine the category paths (facets) to be indexed for an AODN term given its URI
+ * This class is used to determine the category paths (facets) to be indexed for an AODN term given its URI or Label
  */
 
 public class UriLabelClassifier implements Classifier  {

--- a/web/src/main/webapp/WEB-INF/config-summary.xml
+++ b/web/src/main/webapp/WEB-INF/config-summary.xml
@@ -70,17 +70,17 @@
 			<param name="classificationScheme" type="java.lang.String" value="http://vocab.aodn.org.au/def/organisation_classes/1"/>
 			<param name="indexKey" type="java.lang.String" value="orgUnit"/>
 		</dimension>
-		<dimension name="platformCategories" indexKey="platformUri" label="Platform" classifier="au.org.emii.classifier.UriClassifier">
+		<dimension name="platformCategories" indexKey="platformKeyword" label="Platform" classifier="au.org.emii.classifier.UriLabelClassifier">
 			<param name="thesaurusFinder" type="org.fao.geonet.kernel.ThesaurusFinder"/> 
-			<param name="vocabularyScheme" type="java.lang.String" value="http://vocab.aodn.org.au/PlatformClassificationScheme/SchemeNumber1"/>
-			<param name="classificationScheme" type="java.lang.String" value="http://vocab.aodn.org.au/PlatformClassificationScheme/SchemeNumber1"/>
-			<param name="indexKey" type="java.lang.String" value="platformUri"/>
+			<param name="vocabularyScheme" type="java.lang.String" value="http://vocab.aodn.org.au/def/platform/1"/>
+			<param name="classificationScheme" type="java.lang.String" value="http://vocab.aodn.org.au/def/platform_classes/1"/>
+			<param name="indexKey" type="java.lang.String" value="platformKeyword"/>
 		</dimension>
-		<dimension name="parameterCategories" indexKey="parameterUri" label="Measured parameter" classifier="au.org.emii.classifier.UriClassifier">
+		<dimension name="parameterCategories" indexKey="parameterKeyword" label="Measured parameter" classifier="au.org.emii.classifier.UriLabelClassifier">
 			<param name="thesaurusFinder" type="org.fao.geonet.kernel.ThesaurusFinder"/> 
-			<param name="vocabularyScheme" type="java.lang.String" value="http://vocab.aodn.org.au/ParameterClassificationScheme/SchemeNumber1"/>
-			<param name="classificationScheme" type="java.lang.String" value="http://vocab.aodn.org.au/ParameterClassificationScheme/SchemeNumber1"/>
-			<param name="indexKey" type="java.lang.String" value="parameterUri"/>
+			<param name="vocabularyScheme" type="java.lang.String" value="http://vocab.aodn.org.au/def/discovery_parameter/1"/>
+			<param name="classificationScheme" type="java.lang.String" value="http://vocab.aodn.org.au/def/parameter_classes/1"/>
+			<param name="indexKey" type="java.lang.String" value="parameterKeyword"/>
 		</dimension>
 		<dimension name="temporalResolutionCategories" label="Temporal Resolution" indexKey="temporalAggregation"/>
 	</dimensions>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
@@ -255,19 +255,33 @@
 
 				<!-- Index platforms -->
 
-				<xsl:if test="gmd:thesaurusName/*/gmd:title/*/text()='AODN Platform Vocabulary'">
+				<xsl:if test="gmd:thesaurusName/*/gmd:title/*/text()='theme.aodn_aodn-platform-vocabulary.rdf'">
 					<xsl:for-each select="gmd:keyword/*">
 						<Field name="platform" string="{text()}" store="true" index="true"/>
-						<Field name="platformUri" string="{@xlink:href}" store="true" index="true"/>
+						<xsl:choose>
+							<xsl:when test="@xlink:href">
+								<Field name="platformKeyword" string="{@xlink:href}" store="true" index="true"/>
+							</xsl:when>
+							<xsl:otherwise>
+								<Field name="platformKeyword" string="{text()}" store="true" index="true"/>
+							</xsl:otherwise>
+						</xsl:choose>
 					</xsl:for-each>
 				</xsl:if>
 
 				<!-- Index parameters -->
 
-				<xsl:if test="gmd:thesaurusName/*/gmd:title/*/text()='AODN Discovery Parameter Vocabulary'">
+				<xsl:if test="gmd:thesaurusName/*/gmd:title/*/text()='theme.aodn_aodn-discovery-parameter-vocabulary.rdf'">
 					<xsl:for-each select="gmd:keyword/*">
 						<Field name="longParamName" string="{text()}" store="true" index="true"/>
-						<Field name="parameterUri" string="{@xlink:href}" store="true" index="true"/>
+						<xsl:choose>
+							<xsl:when test="@xlink:href">
+								<Field name="parameterKeyword" string="{@xlink:href}" store="true" index="true"/>
+							</xsl:when>
+							<xsl:otherwise>
+								<Field name="parameterKeyword" string="{text()}" store="true" index="true"/>
+							</xsl:otherwise>
+						</xsl:choose>
 					</xsl:for-each>
 				</xsl:if>
 

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
@@ -255,7 +255,7 @@
 
 				<!-- Index platforms -->
 
-				<xsl:if test="gmd:thesaurusName/*/gmd:title/*/text()='theme.aodn_aodn-platform-vocabulary.rdf'">
+				<xsl:if test="gmd:thesaurusName/*/gmd:title/*/text()='AODN Platform Vocabulary'">
 					<xsl:for-each select="gmd:keyword/*">
 						<Field name="platform" string="{text()}" store="true" index="true"/>
 						<xsl:choose>
@@ -271,7 +271,7 @@
 
 				<!-- Index parameters -->
 
-				<xsl:if test="gmd:thesaurusName/*/gmd:title/*/text()='theme.aodn_aodn-discovery-parameter-vocabulary.rdf'">
+				<xsl:if test="gmd:thesaurusName/*/gmd:title/*/text()='AODN Discovery Parameter Vocabulary'">
 					<xsl:for-each select="gmd:keyword/*">
 						<Field name="longParamName" string="{text()}" store="true" index="true"/>
 						<xsl:choose>

--- a/web/src/test/java/au/org/emii/classifier/LabelClassifierTest.java
+++ b/web/src/test/java/au/org/emii/classifier/LabelClassifierTest.java
@@ -18,6 +18,7 @@ public class LabelClassifierTest {
 
     private static final String VOCABULARY_SCHEME = "http://www.my.com/test_vocabulary";
     private static final String CLASSIFICATION_SCHEME = "http://www.my.com/test_classification";
+    private final String indexKey = "";
     
     private static ThesaurusFinder thesaurusFinder;
 
@@ -31,7 +32,7 @@ public class LabelClassifierTest {
     
     @Before
     public void setup() {
-        labelClassifier = new LabelClassifier(thesaurusFinder, VOCABULARY_SCHEME, CLASSIFICATION_SCHEME);
+        labelClassifier = new LabelClassifier(thesaurusFinder, VOCABULARY_SCHEME, CLASSIFICATION_SCHEME, indexKey);
     }
 
     @Test

--- a/web/src/test/java/au/org/emii/classifier/UriClassifierTest.java
+++ b/web/src/test/java/au/org/emii/classifier/UriClassifierTest.java
@@ -18,6 +18,7 @@ public class UriClassifierTest {
 
     private static final String VOCABULARY_SCHEME = "http://www.my.com/test_vocabulary";
     private static final String CLASSIFICATION_SCHEME = "http://www.my.com/test_classification";
+    private final String indexKey = "";
     
     private static ThesaurusFinder thesaurusFinder;
 
@@ -28,10 +29,10 @@ public class UriClassifierTest {
         URL thesauriDirectory = UriClassifier.class.getResource("/thesauri");
         thesaurusFinder = new ThesaurusDirectoryLoader(thesauriDirectory.getFile());
     }
-    
+
     @Before
     public void setup() {
-        uriClassifier = new UriClassifier(thesaurusFinder, VOCABULARY_SCHEME, CLASSIFICATION_SCHEME);
+        uriClassifier = new UriClassifier(thesaurusFinder, VOCABULARY_SCHEME, CLASSIFICATION_SCHEME, indexKey);
     }
 
     @Test

--- a/web/src/test/java/au/org/emii/classifier/UriLabelClassifierTest.java
+++ b/web/src/test/java/au/org/emii/classifier/UriLabelClassifierTest.java
@@ -1,0 +1,129 @@
+package au.org.emii.classifier;
+
+import org.apache.lucene.facet.taxonomy.CategoryPath;
+import org.fao.geonet.kernel.ThesaurusFinder;
+import org.fao.geonet.kernel.search.classifier.Classifier;
+import org.fao.geonet.test.ThesaurusDirectoryLoader;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.List;
+
+import static org.fao.geonet.test.CategoryTestHelper.assertCategoryListEquals;
+import static org.junit.Assert.assertEquals;
+
+public class UriLabelClassifierTest {
+
+    private static final String VOCABULARY_SCHEME = "http://www.my.com/test_vocabulary";
+    private static final String CLASSIFICATION_SCHEME = "http://www.my.com/test_classification";
+    private final String indexKey = "";
+
+    private static ThesaurusFinder thesaurusFinder;
+
+    private Classifier uriLabelClassifier;
+
+    @BeforeClass
+    static public void loadThesauri() {
+        URL thesauriDirectory = UriLabelClassifier.class.getResource("/thesauri");
+        thesaurusFinder = new ThesaurusDirectoryLoader(thesauriDirectory.getFile());
+    }
+
+    @Before
+    public void setup() {
+        uriLabelClassifier = new UriLabelClassifier(thesaurusFinder, VOCABULARY_SCHEME, CLASSIFICATION_SCHEME, indexKey);
+    }
+
+    @Test
+    public void testClassifyHierarchyWithBroaderTerms() {
+        List<CategoryPath> result = uriLabelClassifier.classify("http://www.my.com/test_vocabulary/#sea_surface_temperature");
+        assertCategoryListEquals(result, "ocean/ocean temperature/sea surface temperature");
+    }
+
+    @Test
+    public void testClassifyTermWithMultipleBroaderTerms() {
+        List<CategoryPath> result = uriLabelClassifier.classify("http://www.my.com/test_vocabulary/#air_sea_flux");
+        assertCategoryListEquals(result, "physical - water/air sea flux", "physical - air/air sea flux");
+    }
+
+    @Test
+    public void testClassifyTermWithNoBroaderTerms() {
+        List<CategoryPath> result = uriLabelClassifier.classify("http://www.my.com/test_vocabulary/#longitude");
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testClassifyTermDoesNotExist() {
+        List<CategoryPath> result = uriLabelClassifier.classify("http://www.my.com/test_vocabulary/#unknown_term");
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testDeepDrilldownFacet() {
+        List<CategoryPath> result = uriLabelClassifier.classify("http://www.my.com/test_vocabulary/#hubble");
+        assertCategoryListEquals(result, "space junk/satellite/orbitting satellite/hubble telescope");
+    }
+
+    // Organisation facets tests
+
+    @Test
+    public void testRelatedMatch() {
+        List<CategoryPath> result = uriLabelClassifier.classify("http://www.my.com/test_vocabulary/#aatams");
+        assertCategoryListEquals(result, "Integrated Marine Observing System (IMOS)/Animal Tracking Facility");
+    }
+
+    @Test
+    public void testRelatedMatchTermOnly() {
+        List<CategoryPath> result = uriLabelClassifier.classify("http://www.my.com/test_vocabulary/#imos");
+        assertCategoryListEquals(result, "Integrated Marine Observing System (IMOS)");
+    }
+
+    @Test
+    public void testDisplayLabelTerm() {
+        List<CategoryPath> result = uriLabelClassifier.classify("http://www.my.com/test_vocabulary/#aatams");
+        assertCategoryListEquals(result, "Integrated Marine Observing System (IMOS)/Animal Tracking Facility");
+    }
+
+    @Test
+    public void testPreferredLabelLookup() {
+        List<CategoryPath> result = uriLabelClassifier.classify("Animal Tracking Facility, Integrated Marine Observing System (IMOS)");
+        assertCategoryListEquals(result, "Integrated Marine Observing System (IMOS)/Animal Tracking Facility");
+    }
+
+    @Test
+    public void testAlternateLabelLookup() {
+        List<CategoryPath> result = uriLabelClassifier.classify("AATAMS");
+        assertCategoryListEquals(result, "Integrated Marine Observing System (IMOS)/Animal Tracking Facility");
+    }
+
+    @Test
+    public void testMultipleAlternateLabelLookup() {
+        List<CategoryPath> result = uriLabelClassifier.classify("SOOP");
+        assertCategoryListEquals(result, "Integrated Marine Observing System (IMOS)/Ships of Opportunity Facility (SOOP)");
+    }
+
+    @Test
+    public void testLabelNotFoundLookup() {
+        List<CategoryPath> result = uriLabelClassifier.classify("MISSING");
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testMultipleReplacedBysFound() {
+        List<CategoryPath> result = uriLabelClassifier.classify("Australian Institute of Marine Science (AIMS)");
+        assertCategoryListEquals(result, "Australian Institute of Marine Science (AIMS) 3");
+    }
+
+    @Test
+    public void testOneReplacedByFound() {
+        List<CategoryPath> result = uriLabelClassifier.classify("Australian Institute of Marine Science (AIMS), Department of Industry, Innovation and Science, Australian Government");
+        assertCategoryListEquals(result, "Australian Institute of Marine Science (AIMS) 2");
+    }
+
+    @Test
+    public void testUsesAltLabelIfPresent() {
+        List<CategoryPath> result = uriLabelClassifier.classify("Argo Floats Facility");
+        assertCategoryListEquals(result, "Integrated Marine Observing System (IMOS)/Argo Floats Facility");
+    }
+}


### PR DESCRIPTION
Indexes the keywords `platformKeyword` and `parameterKeyword` from 19115-3 records and alters the config to use these keywords as in index in lieu of the original `parameterUri` and `platformUri`. 

The introduction of a new `UriLabelClassifier`, which acts as a proxy for either a URI or a prefLabel, allows backward compatibility with existing harvesting methods that include adding a URI to the metadata.