### PR TITLE
Update harvester for GN3

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -80,8 +80,12 @@ public class Aligner
 		result  = new GeonetResult();
 
 		//--- save remote categories and groups into hashmaps for a fast access
-
-		List list = remoteInfo.getChild("groups").getChildren("group");
+		Element groups = remoteInfo.getChild("groups");
+		if(groups == null){
+			// Check if GN3 format
+			groups = remoteInfo.getChild("group");
+		}
+		List list = groups.getChildren("group");
 		setupLocEntity(list, hmRemoteGroups);
 	}
 

--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -778,7 +778,7 @@ public class Aligner
 		request.addParam("uuid",   uuid);
 		request.addParam("format", (params.mefFormatFull ? "full" : "partial"));
 
-		request.setAddress(params.getServletPath() +"/srv/en/"+ Geonet.Service.MEF_EXPORT);
+		request.setAddress(params.getServletPath() +"/srv/eng/"+ Geonet.Service.MEF_EXPORT);
 
 		File tempFile = File.createTempFile("temp-", ".dat");
 		request.executeLarge(tempFile);

--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
@@ -106,7 +106,7 @@ class Harvester
 
 		log.info("Retrieving information from : "+ params.host);
 
-		req.setAddress(params.getServletPath() +"/srv/en/"+ Geonet.Service.XML_INFO);
+		req.setAddress(params.getServletPath() +"/srv/eng/"+ Geonet.Service.XML_INFO);
 		req.clearParams();
 		req.addParam("type", "sources");
 		req.addParam("type", "groups");
@@ -186,7 +186,7 @@ class Harvester
 
 	private Element doSearch(XmlRequest request, Search s) throws OperationAbortedEx
 	{
-		request.setAddress(params.getServletPath() +"/srv/en/"+ Geonet.Service.XML_SEARCH);
+		request.setAddress(params.getServletPath() +"/srv/eng/"+ Geonet.Service.XML_SEARCH);
 		
 		try
 		{


### PR DESCRIPTION
When using a GeoNetwork 2 instance to harvest from a GeoNetwork 3 instance a series of invalid XML errors occur due to the change in the formatting of the language type. GN3 appears to only allow a 3 character representation of the language however GN2 allows either 2 or 3 character representations.

The hierarchical structure of the groups also appears to have different tiers, possibly an issue with GN3 however its easiest to resolve the issue from our fork of GN2.

This fix is required for the PR https://github.com/aodn/aodn-portal/pull/2837 to function correctly.