### PR TITLE
Update GN2 to harvest 19139 records that are packaged with 19115-3.2018 records

### DIFF
--- a/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/web/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -153,8 +153,7 @@ public class Aligner
 		{
 			result.totalMetadata++;
 
-			if (!dataMan.existsSchema(ri.schema))
-			{
+			if (!dataMan.existsSchema(ri.schema) && !ri.schema.startsWith("iso19115-3.2018")) {
                 if(log.isDebugEnabled())
                     log.debug("  - Metadata skipped due to unknown schema. uuid:"+ ri.uuid
 						 	+", schema:"+ ri.schema);
@@ -223,7 +222,7 @@ public class Aligner
 
 		try
 		{
-			MEFLib.visit(mefFile, new MEFVisitor(), new IMEFVisitor()
+			MEFLib.visit(mefFile, new MEFVisitor("iso19139", ri), new IMEFVisitor()
 			{
 				public void handleMetadata(Element mdata, int index) throws Exception
 				{
@@ -523,7 +522,7 @@ public class Aligner
 
 			try
 			{
-				MEFLib.visit(mefFile, new MEFVisitor(), new IMEFVisitor()
+				MEFLib.visit(mefFile, new MEFVisitor("iso19139", ri), new IMEFVisitor()
 				{
 					public void handleMetadata(Element mdata, int index) throws Exception
 					{
@@ -777,6 +776,12 @@ public class Aligner
 		request.clearParams();
 		request.addParam("uuid",   uuid);
 		request.addParam("format", (params.mefFormatFull ? "full" : "partial"));
+
+		// Request MEF2 format - if remote node is old
+		// it will ignore this parameter and return a MEF1 format
+		// which will be handle in addMetadata/updateMetadata.
+		request.addParam("version", "2");
+		request.addParam("relation", "false");
 
 		request.setAddress(params.getServletPath() +"/srv/eng/"+ Geonet.Service.MEF_EXPORT);
 

--- a/web/src/main/java/org/fao/geonet/kernel/mef/MEFVisitor.java
+++ b/web/src/main/java/org/fao/geonet/kernel/mef/MEFVisitor.java
@@ -93,7 +93,6 @@ public class MEFVisitor implements IVisitor {
 					md = Xml.loadStream(isb);
 
 				if (simpleName.equals(this.preferredMetadataFile)) {
-					this.recordInfo.schema = this.preferredSchema;
 					preferredMd = Xml.loadStream(isb);
 				}
 
@@ -106,6 +105,7 @@ public class MEFVisitor implements IVisitor {
 		}
 
 		if(preferredMd != null && originalSchema.equals("iso19115-3.2018"))
+			this.recordInfo.schema = this.preferredSchema;
 			md = preferredMd;
 
 		if (md == null)


### PR DESCRIPTION
19115-3.2018 records always contain an iso19139 version. The default behaviour of GN2 is to reject the record as the 19115-3 schema is not recognised. This update adds the ability to search the harvested zip archive for the 19139 version of the record and use that in its place.

[Backlog Item #1508](https://github.com/aodn/backlog/issues/1508)