### PR TITLE
Fixes aodn/issues#441

### DIFF
--- a/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
+++ b/web/src/main/java/org/fao/geonet/monitor/onlineresource/OnlineResourceMonitorService.java
@@ -14,6 +14,7 @@ import org.joda.time.DateTime;
 import org.springframework.context.ApplicationContext;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -206,12 +207,15 @@ public class OnlineResourceMonitorService implements OnlineResourceMonitorInterf
             }
         }
 
-        for (Map.Entry<String, MetadataRecordInfo> record : recordMap.entrySet()) {
+        Iterator<Map.Entry<String, MetadataRecordInfo>> entryIterator = recordMap.entrySet().iterator();
+        
+        while (entryIterator.hasNext()) {
+            Map.Entry<String, MetadataRecordInfo> record = entryIterator.next();
             String title = record.getValue().getTitle();
             if (! records.containsKey(record.getKey())) {
                 // Record was deleted
                 logger.info(String.format("Deleting metadata record title=%s uuid=%s ", title, record.getKey()));
-                recordMap.remove(record.getKey());
+                entryIterator.remove();
             }
         }
         reindexTimestamp = System.currentTimeMillis() / 1000l;


### PR DESCRIPTION
Fix ConcurrentModificationException when reindexing metadata after a record has been deleted.

You can't remove an item from a HashMap while you are iterating over it unless you use an iterator.

An exception thrown here stops online resource checks being performed.

Note that records are only ever marked as deleted on the lucene index and so are still included by the online resource monitor when reindexing its internal index.   Only rebuilding the lucene index actually removes the record, which is why this was happening only when running the config-manager script which kicks off a index rebuild after records had been deleted by the harvester.

