### PR TITLE
Fixes aodn/backlog#1783

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/process/linkage-updater.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/process/linkage-updater.xsl
@@ -1,0 +1,68 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:gco="http://www.isotc211.org/2005/gco"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:mcp="http://bluenet3.antcrc.utas.edu.au/mcp"
+    xmlns:geonet="http://www.fao.org/geonetwork"
+    exclude-result-prefixes="mcp geonet"
+    version="2.0">
+    
+    <xsl:output indent="yes"/>
+
+    <xsl:param name="pattern"/>
+    <xsl:param name="replacement"/>
+    <xsl:param name="pot_url"/> <!-- point-of-truth url to add (templated ${uuid} is replaced witch actual uuid)-->
+
+    <xsl:variable name="metadata-uuid" select="//gmd:fileIdentifier/*/text()"/>
+
+    <!-- default action is to copy -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Always remove geonet:* elements. -->
+    <xsl:template match="geonet:*"/>
+
+    <xsl:template match="gmd:URL[normalize-space($pattern) != '' and matches(text(), $pattern)]">
+        <xsl:copy>
+            <xsl:value-of select="replace(text(), $pattern, $replacement)"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WMS-1.1.1-http-get-map']" priority="100">
+        <xsl:copy><xsl:value-of select="replace(., concat($pattern,'/geoserver'), 'https://tilecache.aodn.org.au/geowebcache/service')"/></xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WMS-1.3.0-http-get-map']" priority="100">
+        <xsl:copy><xsl:value-of select="replace(., concat($pattern,'/geoserver'), 'https://tilecache.aodn.org.au/geowebcache/service')"/></xsl:copy>
+    </xsl:template>
+
+    <!-- Add point of truth online resource element to the first transferOptions -->
+    <!-- element in the MD_Distribution section if pot_url provided and it       -->
+    <!-- doesn't exist already             -->
+
+    <xsl:variable name="has-pot" select="//gmd:MD_Distribution//gmd:protocol/*/text()[.='WWW:LINK-1.0-http--metadata-URL']"/>
+
+    <xsl:variable name="add-pot" select="$pot_url and not($has-pot)"/>
+
+    <xsl:template match="gmd:MD_Distribution[$add-pot]/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions[1]">
+        <xsl:copy>
+            <xsl:apply-templates select="node()"/>
+            <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                    <gmd:linkage>
+                        <gmd:URL><xsl:value-of select="replace($pot_url, '\$\{uuid\}', $metadata-uuid)"/></gmd:URL>
+                    </gmd:linkage>
+                    <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK-1.0-http--metadata-URL</gco:CharacterString>
+                    </gmd:protocol>
+                    <gmd:description>
+                        <gco:CharacterString>Point of truth URL of this metadata record</gco:CharacterString>
+                    </gmd:description>
+                </gmd:CI_OnlineResource>
+            </gmd:onLine>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/process/systest-catalogue-imos-harvest.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/process/systest-catalogue-imos-harvest.xsl
@@ -1,0 +1,80 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:gco="http://www.isotc211.org/2005/gco"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:mcp="http://bluenet3.antcrc.utas.edu.au/mcp"
+    exclude-result-prefixes="mcp"
+    version="2.0">
+
+    <xsl:param name="pot_url"/> <!-- point-of-truth url to add (templated ${uuid} is replaced witch actual uuid)-->
+
+    <xsl:variable name="metadata-uuid" select="//gmd:fileIdentifier/*/text()"/>
+
+    <!-- url substitutions to be performed -->
+
+    <xsl:variable name="urlSubstitutions">
+        <substitution match="https?://geoserver-123.aodn.org.au(:443)?" replaceWith="http://geoserver-systest.aodn.org.au"/>
+        <substitution match="https?://thredds.aodn.org.au(:443)?" replaceWith="http://thredds-systest.aodn.org.au"/>
+    </xsl:variable>
+
+    <xsl:variable name="urlSubstitutionSelector" select="string-join($urlSubstitutions/substitution/@match, '|')"/>
+
+    <!-- default action is to copy -->
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- substitute production service endpoints with systest service endpoints -->
+
+    <xsl:template match="gmd:URL[matches(., $urlSubstitutionSelector)]">
+        <xsl:variable name="url" select="."/>
+
+        <xsl:for-each select="$urlSubstitutions/substitution">
+            <xsl:if test="matches(string($url), string(@match))">
+                <gmd:URL><xsl:value-of select="replace($url, string(@match), string(@replaceWith))"/></gmd:URL>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+
+	<xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WPS--gogoduck']">
+        <gmd:URL><xsl:value-of select="replace(.,'https?://processes.aodn.org.au', 'https://processes-systest.aodn.org.au')"/></gmd:URL>
+    </xsl:template>
+
+    <xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WMS-1.1.1-http-get-map']" priority="100">
+        <gmd:URL><xsl:value-of select="replace(.,'https?://geoserver-123.aodn.org.au/geoserver', 'https://tilecache-systest.aodn.org.au/geowebcache/service')"/></gmd:URL>
+    </xsl:template>
+
+    <xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WMS-1.3.0-http-get-map']" priority="100">
+        <xsl:copy><xsl:value-of select="replace(., 'https?://geoserver-123.aodn.org.au/geoserver', 'https://tilecache-systest.aodn.org.au/geowebcache/service')"/></xsl:copy>
+    </xsl:template>
+
+    <!-- Add point of truth online resource element to the first transferOptions -->
+    <!-- element in the MD_Distribution section if pot_url provided and it       -->
+    <!-- doesn't exist already             -->
+
+    <xsl:variable name="has-pot" select="//gmd:MD_Distribution//gmd:protocol/*/text()[.='WWW:LINK-1.0-http--metadata-URL']"/>
+
+    <xsl:variable name="add-pot" select="$pot_url and not($has-pot)"/>
+
+    <xsl:template match="gmd:MD_Distribution[$add-pot]/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions[1]">
+        <xsl:copy>
+            <xsl:apply-templates select="node()"/>
+            <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                    <gmd:linkage>
+                        <gmd:URL><xsl:value-of select="replace($pot_url, '\$\{uuid\}', $metadata-uuid)"/></gmd:URL>
+                    </gmd:linkage>
+                    <gmd:protocol>
+                        <gco:CharacterString>WWW:LINK-1.0-http--metadata-URL</gco:CharacterString>
+                    </gmd:protocol>
+                    <gmd:description>
+                        <gco:CharacterString>Point of truth URL of this metadata record</gco:CharacterString>
+                    </gmd:description>
+                </gmd:CI_OnlineResource>
+            </gmd:onLine>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/process/transform_testing_urls.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/process/transform_testing_urls.xsl
@@ -1,0 +1,48 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:gco="http://www.isotc211.org/2005/gco"
+    xmlns:gmd="http://www.isotc211.org/2005/gmd"
+    xmlns:mcp="http://bluenet3.antcrc.utas.edu.au/mcp"
+    exclude-result-prefixes="mcp"
+    version="2.0">
+
+    <!-- url substitutions to be performed -->
+
+    <xsl:variable name="urlSubstitutions">
+        <substitution match="https?://geoserver-portal.aodn.org.au(:443)?" replaceWith="http://geoserver-systest.aodn.org.au"/>
+        <substitution match="https?://thredds.aodn.org.au(:443)?" replaceWith="http://thredds-systest.aodn.org.au"/>
+    </xsl:variable>
+
+    <xsl:variable name="urlSubstitutionSelector" select="string-join($urlSubstitutions/substitution/@match, '|')"/>
+
+    <!-- default action is to copy -->
+
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- substitute production service endpoints with systest service endpoints -->
+
+    <xsl:template match="gmd:URL[matches(., $urlSubstitutionSelector)]">
+        <xsl:variable name="url" select="."/>
+
+        <xsl:for-each select="$urlSubstitutions/substitution">
+            <xsl:if test="matches(string($url), string(@match))">
+                <gmd:URL><xsl:value-of select="replace($url, string(@match), string(@replaceWith))"/></gmd:URL>
+            </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+
+	<xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WPS--gogoduck']">
+        <gmd:URL><xsl:value-of select="replace(.,'https?://processes.aodn.org.au', 'https://processes-systest.aodn.org.au')"/></gmd:URL>
+    </xsl:template>
+
+    <xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WMS-1.1.1-http-get-map']" priority="100">
+        <gmd:URL><xsl:value-of select="replace(.,'https?://tilecache.aodn.org.au(:443)?', 'https://tilecache-systest.aodn.org.au')"/></gmd:URL>
+    </xsl:template>
+
+    <xsl:template match="gmd:URL[../../gmd:protocol/*/text()='OGC:WMS-1.3.0-http-get-map']" priority="100">
+        <gmd:URL><xsl:value-of select="replace(.,'https?://tilecache.aodn.org.au(:443)?', 'https://tilecache-systest.aodn.org.au')"/></gmd:URL>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Add specific transform for converting catalogue-imos url's to systest url's.

Also add normal linkage-updater and transform_testing_urls transforms for catalogue-portal harvesting and normal systest harvesting after the upgrade.

#### Test results

Example gridded and non-gridded output of records transformed using systest-catalogue-imos-harvest.xsl:

[acorn.txt](https://github.com/aodn/core-geonetwork/files/4762763/acorn.txt)
[argo.txt](https://github.com/aodn/core-geonetwork/files/4762764/argo.txt)

Example gridded and non-gridded output performed locally using linkage-updater:

[acorn-portal.txt](https://github.com/aodn/core-geonetwork/files/4762768/acorn-portal.txt)
[argo-portal.txt](https://github.com/aodn/core-geonetwork/files/4762769/argo-portal.txt)

Example gridded and non-gridded output of above 'catalogue-portal' records using transform_testing_urls:

[acorn-systest.txt](https://github.com/aodn/core-geonetwork/files/4762772/acorn-systest.txt)
[argo-systest.txt](https://github.com/aodn/core-geonetwork/files/4762774/argo-systest.txt)

Note that these are exactly the same as the systest-catalogue-imos-harvest.xsl result.


