### PR TITLE
Fixes aodn/backlog#1788

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/index-fields.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet version="2.0" xmlns:gmd="http://www.isotc211.org/2005/gmd"
 										xmlns:gco="http://www.isotc211.org/2005/gco"
 										xmlns:gml="http://www.opengis.net/gml"
+										xmlns:gml32="http://www.opengis.net/gml/3.2"
 										xmlns:srv="http://www.isotc211.org/2005/srv"
 										xmlns:geonet="http://www.fao.org/geonetwork"
 										xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
@@ -208,11 +209,17 @@
 				</xsl:for-each>>
 
 				<xsl:for-each select="gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent">
-					<xsl:for-each select="gml:TimePeriod">
+					<xsl:for-each select="gml:TimePeriod|gml32:TimePeriod">
 						<xsl:variable name="times">
 							<xsl:call-template name="newGmlTime">
-								<xsl:with-param name="begin" select="gml:beginPosition|gml:begin/gml:TimeInstant/gml:timePosition"/>
-								<xsl:with-param name="end" select="gml:endPosition|gml:end/gml:TimeInstant/gml:timePosition"/>
+								<xsl:with-param name="begin" select="gml:beginPosition
+								                                    |gml32:beginPosition
+								                                    |gml:begin|gml:TimeInstant/gml:timePosition
+								                                    |gml32:begin|gml32:TimeInstant/gml32:timePosition"/>
+								<xsl:with-param name="end" select="gml:endPosition
+								                                  |gml32:endPosition
+								                                  |gml:end/gml:TimeInstant/gml:timePosition
+								                                  |gml32:end/gml32:TimeInstant/gml32:timePosition"/>
 							</xsl:call-template>
 						</xsl:variable>
 


### PR DESCRIPTION
Handle new method of namespacing gml3.2 used in 19115-3:2018 and later versions of 19139 when indexing the temporal extent

New namespace is used when converting 19115-3:2018 records to 19139 records in GN3.