### PR TITLE
Fixes aodn/backlog#1798

### DIFF
--- a/jeeves/src/main/java/jeeves/utils/Xml.java
+++ b/jeeves/src/main/java/jeeves/utils/Xml.java
@@ -511,6 +511,8 @@ public final class Xml
 			transFact.setAttribute(FeatureKeys.LINE_NUMBERING,true);
 			transFact.setAttribute(FeatureKeys.PRE_EVALUATE_DOC_FUNCTION,false);
 			transFact.setAttribute(FeatureKeys.RECOVERY_POLICY,Configuration.RECOVER_SILENTLY);
+			// Add the following to trace xsl execution
+			//transFact.setAttribute(FeatureKeys.TRACE_LISTENER, new net.sf.saxon.trace.XSLTTraceListener());
 			// Add the following to get timing info on xslt transformations
 			//transFact.setAttribute(FeatureKeys.TIMING,true);
 		} catch (IllegalArgumentException e) {

--- a/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/extract-gml.xsl
+++ b/web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19139/extract-gml.xsl
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:gmd="http://www.isotc211.org/2005/gmd" version="1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:gco="http://www.isotc211.org/2005/gco" >
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                version="2.0"
+                xmlns:gml="http://www.opengis.net/gml"
+                xmlns:gml32="http://www.opengis.net/gml/3.2"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                exclude-result-prefixes="#all">
     <xsl:output method="xml" indent="no"/>
     <xsl:template match="/" priority="2">
    		<gml:GeometryCollection >
@@ -13,12 +19,12 @@
     
     <xsl:template match="text()"/>
 
-		<xsl:template match="gmd:EX_BoundingPolygon[string(gmd:extentTypeCode/gco:Boolean) != 'false' and string(gmd:extentTypeCode/gco:Boolean) != '0']" priority="2">
-			<xsl:for-each select="gmd:polygon/gml:*">
-				<xsl:copy-of select="."/>
-			</xsl:for-each>
-		</xsl:template>
-    
+    <xsl:template match="gmd:EX_BoundingPolygon[string(gmd:extentTypeCode/gco:Boolean) != 'false' and string(gmd:extentTypeCode/gco:Boolean) != '0']" priority="2">
+        <xsl:for-each select="gmd:polygon/gml:*|.//gml32:Polygon">
+            <xsl:apply-templates mode="gml32-to-gml" select="."/>
+        </xsl:for-each>
+    </xsl:template>
+
     <xsl:template match="gmd:EX_GeographicBoundingBox" priority="2">
         <xsl:variable name="w" select="./gmd:westBoundLongitude/gco:Decimal/text()"/>
         <xsl:variable name="e" select="./gmd:eastBoundLongitude/gco:Decimal/text()"/>
@@ -34,4 +40,27 @@
 	        </gml:Polygon>
         </xsl:if>
     </xsl:template>
+
+    <!-- gml32 to gml mode - changes any gml32 elements or attributes to gml elements or attributes --> 
+    <!-- otherwise just copies the attribute or node to the output -->
+
+    <!-- default rule is to copy -->
+    <xsl:template mode="gml32-to-gml" match='@*|node()'>
+        <xsl:copy copy-namespaces="no">
+            <xsl:apply-templates mode="gml32-to-gml" select='@*|node()'/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- change gml32 attributes to gml attributes -->
+    <xsl:template mode="gml32-to-gml" match="@gml32:*">
+        <xsl:attribute name="gml:{local-name()}" select="."/>
+    </xsl:template>
+
+    <!-- change gml32 elements to gml elements -->
+    <xsl:template mode="gml32-to-gml" match="gml32:*">
+        <xsl:element name="gml:{local-name()}">
+            <xsl:apply-templates mode="gml32-to-gml" select="@*|node()"/>
+        </xsl:element>
+    </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
Handle gml/3.2 namespacing of gml 3.2 bounding polygon's used by 19139 records harvested from GN3 as well as gml namespacing when indexing spatial extents.

